### PR TITLE
upload APK/IPA files to Google Drive

### DIFF
--- a/.github/workflows/build_android_apk.yml
+++ b/.github/workflows/build_android_apk.yml
@@ -89,14 +89,29 @@ jobs:
 #          name: app-release.apk
 #          path: android/app/build/outputs/apk/release/
 
+      - name: Prepare Android APK for upload
+        run: |
+          upload_file=TreeInventory-`echo $GITHUB_REF | awk '{split($0,a,"/"); print a[3]}'`.apk
+          echo "::set-env name=upload_file::$upload_file"
+          mkdir -p uploads
+          mv android/app/build/outputs/apk/release/app-release.apk uploads/$upload_file
+
+      # depends on existence of upload file at uploads/$upload_file
       - name: Upload Android APK to Browserstack
         env:
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
         run: |
-          upload_file=TreeInventory-`echo $GITHUB_REF | awk '{split($0,a,"/"); print a[3]}'`.apk
-          echo "::set-env name=upload_file::$upload_file"
-          mv android/app/build/outputs/apk/release/app-release.apk $upload_file
-          curl -u "planetit1:$BROWSERSTACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-live/upload" -F "file=@$upload_file"
+          curl -u "planetit1:$BROWSERSTACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-live/upload" -F "file=@uploads/$upload_file"
+
+      # depends on existence of upload file in folder uploads
+      - name: Upload Android APK to Google Drive
+        uses: satackey/action-google-drive@v1.2.0
+        with:
+          upload-from: ./uploads
+          upload-to: /GitHubActions/TreeMapperApp/.
+          skicka-tokencache-json: ${{ secrets.SKICKA_TOKENCACHE_JSON }}
+          google-client-id: ${{ secrets.GOOGLE_DRIVE_CLIENT_ID }}
+          google-client-secret: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
 
       - name: Slack notification
         env:

--- a/.github/workflows/macos_build_ios.yml
+++ b/.github/workflows/macos_build_ios.yml
@@ -94,14 +94,29 @@ jobs:
 #        name: TreeInventory-develop-release.ipa
 #        path: ios/DerivedData/ipa/TreeInventory(.env.develop).ipa
 
+    - name: Prepare iOS IPA for upload
+      run: |
+        upload_file=TreeInventory-`echo $GITHUB_REF | awk '{split($0,a,"/"); print a[3]}'`.ipa
+        echo "::set-env name=upload_file::$upload_file"
+        mkdir -p uploads
+        mv 'ios/DerivedData/ipa/treeinventory.ipa' uploads/$upload_file
+
+    # depends on existence of upload file at uploads/$upload_file
     - name: Upload iOS IPA to Browserstack
       env:
         BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
       run: |
-        upload_file=TreeInventory-`echo $GITHUB_REF | awk '{split($0,a,"/"); print a[3]}'`.ipa
-        echo "::set-env name=upload_file::$upload_file"
-        mv 'ios/DerivedData/ipa/treeinventory.ipa' release/$upload_file
-        curl -u "planetit1:$BROWSERSTACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-live/upload" -F "file=@release/$upload_file"
+        curl -u "planetit1:$BROWSERSTACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-live/upload" -F "file=@uploads/$upload_file"
+
+    # depends on existence of upload file in folder uploads
+    - name: Upload iOS IPA to Google Drive
+      uses: satackey/action-google-drive@v1.2.0
+      with:
+        upload-from: ./uploads
+        upload-to: /GitHubActions/TreeMapperApp/.
+        skicka-tokencache-json: ${{ secrets.SKICKA_TOKENCACHE_JSON }}
+        google-client-id: ${{ secrets.GOOGLE_DRIVE_CLIENT_ID }}
+        google-client-secret: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
 
     - name: Slack notification
       env:

--- a/.github/workflows/macos_build_ios.yml
+++ b/.github/workflows/macos_build_ios.yml
@@ -31,9 +31,43 @@ jobs:
         echo "Brew version:"
         brew --version
         echo "Node version:"
+        node --version
+        echo "NPM version:"
         npm --version
         echo "PATH:"
         echo $PATH
+
+    - name: Installing and changing to newer bash version
+      run: |
+        echo $PATH
+        bash -version
+        brew reinstall bash
+        sudo chsh -s /usr/local/bin/bash
+
+    - name: Installing and changing to gnu sed version
+      run: |
+        echo $PATH
+        brew reinstall gnu-sed
+        echo 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"' >> ~/.bashrc
+
+    - name: Installing google-drive-upload script
+      env:
+        CLIENT_ID: ${{ secrets.GOOGLE_DRIVE_CLIENT_ID }}
+        CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+        REFRESH_TOKEN: ${{ secrets.GOOGLE_DRIVE_REFRESH_TOKEN }}
+        ACCESS_TOKEN: ${{ secrets.GOOGLE_DRIVE_ACCESS_TOKEN }}
+      run: |
+        source ~/.bashrc
+        echo $PATH
+        bash <(curl --compressed -s https://raw.githubusercontent.com/labbots/google-drive-upload/master/install.sh)
+        #bash <(curl --compressed -# https://raw.githubusercontent.com/Akianonymus/google-drive-upload/fix/install.sh) -r Akianonymus/google-drive-upload -B fix
+        echo "CLIENT_ID=\"$CLIENT_ID\"" >> ~/.googledrive.conf
+        echo "CLIENT_SECRET=\"$CLIENT_SECRET\"" >> ~/.googledrive.conf
+        echo "REFRESH_TOKEN=\"$REFRESH_TOKEN\"" >> ~/.googledrive.conf
+        echo "ACCESS_TOKEN=\"$ACCESS_TOKEN\"" >> ~/.googledrive.conf
+        echo "ACCESS_TOKEN_EXPIRY=" >> ~/.googledrive.conf
+        echo "ROOT_FOLDER=\"1sO16rDuJA8McRA8-Q-I6R2OjMGcG4nEp\"" >> ~/.googledrive.conf
+        echo "ROOT_FOLDER_NAME=" >> ~/.googledrive.conf
 
     - name: Caching node modules
       uses: actions/cache@v1
@@ -108,15 +142,11 @@ jobs:
       run: |
         curl -u "planetit1:$BROWSERSTACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-live/upload" -F "file=@uploads/$upload_file"
 
-    # depends on existence of upload file in folder uploads
+    # depends on existence of upload file at uploads/$upload_file
     - name: Upload iOS IPA to Google Drive
-      uses: satackey/action-google-drive@v1.2.0
-      with:
-        upload-from: ./uploads
-        upload-to: /GitHubActions/TreeMapperApp/.
-        skicka-tokencache-json: ${{ secrets.SKICKA_TOKENCACHE_JSON }}
-        google-client-id: ${{ secrets.GOOGLE_DRIVE_CLIENT_ID }}
-        google-client-secret: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      run: |
+        source ~/.bashrc
+        gupload -C TreeMapperApp uploads/$upload_file
 
     - name: Slack notification
       env:


### PR DESCRIPTION
Changes:
- enhance GitHub Actions to upload IPA and APK files to Google Drive for future use.